### PR TITLE
商品購入機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,8 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 
 gem 'active_hash'
+
+gem 'payjp'
+
+gem 'pry'
+gem 'pry-byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -93,3 +93,5 @@ gem 'payjp'
 
 gem 'pry'
 gem 'pry-byebug'
+
+gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     builder (3.3.0)
+    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -85,6 +86,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.3.4)
     crass (1.0.6)
     date (3.4.0)
@@ -98,6 +100,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.1)
+    domain_name (0.6.20240107)
     erubi (1.13.0)
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
@@ -110,6 +113,9 @@ GEM
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    http-accept (1.7.0)
+    http-cookie (1.0.7)
+      domain_name (~> 0.5)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     image_processing (1.13.0)
@@ -140,6 +146,10 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
+    mime-types (3.6.0)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.1105)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.1)
@@ -154,6 +164,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
@@ -164,7 +175,15 @@ GEM
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
+    payjp (0.0.16)
+      rest-client (~> 2.0)
     pg (1.5.9)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     psych (5.2.0)
       stringio
     public_suffix (6.0.1)
@@ -212,6 +231,11 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.3.9)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
@@ -305,7 +329,10 @@ DEPENDENCIES
   jbuilder
   mini_magick
   mysql2 (~> 0.5)
+  payjp
   pg
+  pry
+  pry-byebug
   puma (~> 5.0)
   rails (~> 7.0.0)
   rspec-rails (~> 4.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,11 @@ GEM
     ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
     http-accept (1.7.0)
     http-cookie (1.0.7)
       domain_name (~> 0.5)
@@ -154,6 +159,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.5)
+    multi_json (1.15.0)
     mysql2 (0.5.6)
     net-imap (0.5.1)
       date
@@ -228,6 +234,8 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.11)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -324,6 +332,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  gon
   image_processing (~> 1.2)
   importmap-rails
   jbuilder

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,11 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    if @item.user_id != current_user.id || !@item.order.nil?
+      redirect_to root_path
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def update

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,7 @@
 class OrdersController < ApplicationController
+  before_action :authenticate_user!
   before_action :item_set, only: [:index, :create]
+
   def index
     @order_form = OrderForm.new
   end
@@ -9,9 +11,10 @@ class OrdersController < ApplicationController
   end
 
   def create
-    @order_form = OrderForm.new(order_params)
+    @order_form = OrderForm.new(order_form_params)
     if @order_form.valid?
-      @order_form.save
+      pay_item
+      @order_form.save(params[:item_id], current_user.id)
       redirect_to root_path
     else
       render :index, status: :unprocessable_entity
@@ -24,8 +27,17 @@ class OrdersController < ApplicationController
     @item = Item.find(params[:item_id])
   end
 
-  def order_params
+  def order_form_params
     params.require(:order_form).permit(:post_code, :prefecture_id, :city, :address, :building_name,
-                                       :phone_number).merge(user_id: current_user.id, item_id: params[:item_id])
+                                       :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+  end
+
+  def pay_item
+    Payjp.api_key = 'sk_test_7872f0364472cc0d4b586d15' # 自身のPAY.JPテスト秘密鍵
+    Payjp::Charge.create(
+      amount: @item.price,             # 商品の値段
+      card: order_form_params[:token], # カードトークン
+      currency: 'jpy'                  # 通貨の種類（日本円）
+    )
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,31 @@
+class OrdersController < ApplicationController
+  before_action :item_set, only: [:index, :create]
+  def index
+    @order_form = OrderForm.new
+  end
+
+  def new
+    @order_form = OrderForm.new
+  end
+
+  def create
+    @order_form = OrderForm.new(order_params)
+    if @order_form.valid?
+      @order_form.save
+      redirect_to root_path
+    else
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def item_set
+    @item = Item.find(params[:item_id])
+  end
+
+  def order_params
+    params.require(:order_form).permit(:post_code, :prefecture_id, :city, :address, :building_name,
+                                       :phone_number).merge(user_id: current_user.id, item_id: params[:item_id])
+  end
+end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "items_new"
+import "card"

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,5 +1,6 @@
 const pay = () => {
-  const payjp = Payjp('pk_test_6364157195db3cd7ee5c97bf')// PAY.JPテスト公開鍵
+  const publicKey = gon.public_key
+  const payjp = Payjp(publicKey) // PAY.JPテスト公開鍵
   const elements = payjp.elements();
   const numberElement = elements.create('cardNumber');
   const expiryElement = elements.create('cardExpiry');
@@ -28,3 +29,4 @@ const pay = () => {
 };
 
 window.addEventListener("turbo:load", pay);
+window.addEventListener("turbo:render", pay);

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,30 @@
+const pay = () => {
+  const payjp = Payjp('pk_test_6364157195db3cd7ee5c97bf')// PAY.JPテスト公開鍵
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+  const form = document.getElementById('charge-form')
+  form.addEventListener("submit", (e) => {
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
+    });
+    e.preventDefault();
+  });
+};
+
+window.addEventListener("turbo:load", pay);

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,6 +7,7 @@ class Item < ApplicationRecord
   belongs_to :condition
   belongs_to :prefecture
   belongs_to :delivery_day
+  has_one    :order
 
   validates :title, presence: true
   validates :description, presence: true

--- a/app/models/orde.rb
+++ b/app/models/orde.rb
@@ -1,0 +1,3 @@
+class Purchese < ApplicationRecord
+  
+end

--- a/app/models/orde.rb
+++ b/app/models/orde.rb
@@ -1,3 +1,0 @@
-class Purchese < ApplicationRecord
-  
-end

--- a/app/models/orde_id.rb
+++ b/app/models/orde_id.rb
@@ -1,0 +1,2 @@
+class OrderId < ApplicationRecord
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one    :shipping_address
+end

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -2,15 +2,16 @@ class OrderForm
   include ActiveModel::Model
   attr_accessor :user_id, :item_id, :post_code, :prefecture_id, :city, :address, :building_name, :phone_number, :token
 
-  validates :user_id,  presence: true
-  validates :item_id,  presence: true
-  validates :city,     presence: true
-  validates :address,  presence: true
-  validates :token,    presence: true
-
-  validates :post_code,     format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
-  validates :phone_number,  format: { with: /\A[0-9]{10,11}\z/, message: 'must be 10 or 11 digits long' }
-  validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
+  with_options presence: true do
+    validates :user_id
+    validates :item_id
+    validates :city
+    validates :address
+    validates :token
+    validates :post_code,     format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
+    validates :phone_number,  format: { with: /\A[0-9]{10,11}\z/, message: 'must be 10 or 11 digits long' }
+    validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+  end
 
   def save(item_id, user_id)
     order = Order.create(user_id: user_id, item_id: item_id)

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -1,0 +1,29 @@
+class OrderForm
+  include ActiveModel::Model
+  attr_accessor :user_id, :item_id, :post_code, :prefecture_id, :city, :address, :building_name, :phone_number
+
+  with_options presence: true do
+    validates :user_id
+    validates :item_id
+    validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
+    validates :city
+    validates :address
+    validates :phone_number, format: { with: /\A[0-9]{10,11}\z/, message: 'must be 10 or 11 digits long' }
+
+    validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
+
+    def save
+      order = Order.create(user_id:, item_id:)
+
+      ShippingAddress.create(
+        post_code:,
+        prefecture_id:,
+        city:,
+        address:,
+        building_name:,
+        phone_number:,
+        order_id: order.id
+      )
+    end
+  end
+end

--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -1,29 +1,20 @@
 class OrderForm
   include ActiveModel::Model
-  attr_accessor :user_id, :item_id, :post_code, :prefecture_id, :city, :address, :building_name, :phone_number
+  attr_accessor :user_id, :item_id, :post_code, :prefecture_id, :city, :address, :building_name, :phone_number, :token
 
-  with_options presence: true do
-    validates :user_id
-    validates :item_id
-    validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
-    validates :city
-    validates :address
-    validates :phone_number, format: { with: /\A[0-9]{10,11}\z/, message: 'must be 10 or 11 digits long' }
+  validates :user_id,  presence: true
+  validates :item_id,  presence: true
+  validates :city,     presence: true
+  validates :address,  presence: true
+  validates :token,    presence: true
 
-    validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
+  validates :post_code,     format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Include hyphen(-)' }
+  validates :phone_number,  format: { with: /\A[0-9]{10,11}\z/, message: 'must be 10 or 11 digits long' }
+  validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
 
-    def save
-      order = Order.create(user_id:, item_id:)
-
-      ShippingAddress.create(
-        post_code:,
-        prefecture_id:,
-        city:,
-        address:,
-        building_name:,
-        phone_number:,
-        order_id: order.id
-      )
-    end
+  def save(item_id, user_id)
+    order = Order.create(user_id: user_id, item_id: item_id)
+    ShippingAddress.create(order_id: order.id, post_code: post_code, prefecture_id: prefecture_id, city: city, address: address,
+                           building_name: building_name, phone_number: phone_number)
   end
 end

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -1,0 +1,3 @@
+class ShippingAddress < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
+  has_many :orders
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i
   NAME_REGEX = /\A[ぁ-んァ-ヶ一-龥々ー]+\z/

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,13 +134,11 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
           <% if item.order.present? %>
             <div class='sold-out'>
               <span>Sold Out!!</span>
             </div>
           <% end %>
-          <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -135,9 +135,11 @@
           <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+          <% if item.order.present? %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+          <% end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,7 +31,7 @@
         <p class="or-text">or</p>
         <%= link_to "削除", item_path, data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
-        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <%= link_to "購入画面に進む", item_orders_path(@item.id), data: { turbo: false },class:"item-red-btn"%>
       <% end %>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,9 +10,11 @@
       <%= image_tag @item.image, class:"item-box-img" %>
 
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <% if @item.order.present? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     
     </div>
@@ -25,7 +27,7 @@
       </span>
     </div>
 
-    <% if user_signed_in? %>
+    <% if user_signed_in? && @item.order == nil %>
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,13 +9,11 @@
     <div class="item-img-content">
       <%= image_tag @item.image, class:"item-box-img" %>
 
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <% if @item.order.present? %>
         <div class="sold-out">
           <span>Sold Out!!</span>
         </div>
       <% end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
     
     </div>
     <div class="item-price-box">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.css">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,3 +1,4 @@
+<%= include_gon %>
 <%= render "shared/second-header"%>
 
 <div class='transaction-contents'>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -8,14 +8,14 @@
 
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag @item.image, class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @item.title %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.shipping_fee.name %></p>
         </div>
       </div>
     </div>
@@ -27,7 +27,7 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= @item.price %>
       </p>
     </div>
     <%# /支払額の表示 %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,130 @@
+<%= render "shared/second-header"%>
+
+<div class='transaction-contents'>
+  <div class='transaction-main'>
+    <h1 class='transaction-title-text'>
+      購入内容の確認
+    </h1>
+
+    <%# 購入内容の表示 %>
+    <div class='buy-item-info'>
+      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <div class='buy-item-right-content'>
+        <h2 class='buy-item-text'>
+          <%= "商品名" %>
+        </h2>
+        <div class='buy-item-price'>
+          <p class='item-price-text'>¥<%= '999,999,999' %></p>
+          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+        </div>
+      </div>
+    </div>
+    <%# /購入内容の表示 %>
+
+    <%# 支払額の表示 %>
+    <div class='item-payment'>
+      <h1 class='item-payment-title'>
+        支払金額
+      </h1>
+      <p class='item-payment-price'>
+        ¥<%= "販売価格" %>
+      </p>
+    </div>
+    <%# /支払額の表示 %>
+    
+    <%= form_with model: @order_form, url: item_orders_path(@item.id), id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+
+    <%# カード情報の入力 %>
+    <div class='credit-card-form'>
+      <h1 class='info-input-haedline'>
+        クレジットカード情報入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">カード情報</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="number-form" class="input-default"></div>
+        <div class='available-card'>
+          <%= image_tag 'card-visa.gif', class: 'card-logo'%>
+          <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
+          <%= image_tag 'card-jcb.gif', class: 'card-logo'%>
+          <%= image_tag 'card-amex.gif', class: 'card-logo'%>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">有効期限</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div class='input-expiration-date-wrap'>
+          <div id="expiry-form" class="input-default"></div>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">セキュリティコード</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="cvc-form" class="input-default"></div>
+      </div>
+    </div>
+    <%# /カード情報の入力 %>
+    
+    <%# 配送先の入力 %>
+    <div class='shipping-address-form'>
+      <h1 class='info-input-haedline'>
+        配送先入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">郵便番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">都道府県</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">市区町村</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">番地</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">建物名</label>
+          <span class="form-any">任意</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">電話番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+      </div>
+    </div>
+    <%# /配送先の入力 %>
+
+    <div class='buy-btn'>
+      <%= f.submit "購入" ,class:"buy-red-btn", id:"button" %>
+    </div>
+    <% end %>
+  </div>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -32,7 +32,10 @@
     </div>
     <%# /支払額の表示 %>
     
-    <%= form_with model: @order_form, url: item_orders_path(@item.id), id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: @order_form, url: item_orders_path, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+
+    <%# エラーメッセージの表示 %>
+    <%= render 'shared/error_messages', model: f.object %> 
 
     <%# カード情報の入力 %>
     <div class='credit-card-form'>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -81,42 +81,42 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field :post_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field :address, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field :building_name, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,3 +7,4 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 
 pin "items_new", to: "items_new.js"
+pin "card", to: "card.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items
+  resources :items do
+    resources :orders, only: [:index, :new, :create]
+  end
 end

--- a/db/migrate/20241121075653_create_orders.rb
+++ b/db/migrate/20241121075653_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.references    :user, null: false, foreign_key: true
+      t.references    :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241121120000_create_shipping_addresses.rb
+++ b/db/migrate/20241121120000_create_shipping_addresses.rb
@@ -1,0 +1,14 @@
+class CreateShippingAddresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shipping_addresses do |t|
+      t.references  :order,          null: false, foreign_key: true
+      t.string      :post_code,      null: false
+      t.integer     :prefecture_id,  null: false
+      t.string      :city,           null: false
+      t.string      :address,        null: false
+      t.string      :building_name
+      t.string      :phone_number,   null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_15_075259) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_21_120000) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -54,6 +54,28 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_15_075259) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "orders", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
+  end
+
+  create_table "shipping_addresses", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "order_id", null: false
+    t.string "post_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "address", null: false
+    t.string "building_name"
+    t.string "phone_number", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_shipping_addresses_on_order_id"
+  end
+
   create_table "users", charset: "utf8mb3", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
@@ -75,4 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_15_075259) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
+  add_foreign_key "shipping_addresses", "orders"
 end

--- a/spec/factories/order_form.rb
+++ b/spec/factories/order_form.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :order_form do
+    post_code       { Faker::Number.leading_zero_number(digits: 3) + '-' + Faker::Number.leading_zero_number(digits: 4) }
+    prefecture_id   { 2 }
+    city            { Faker::Address.city }
+    address         { Faker::Address.street_address }
+    phone_number    { Faker::Number.leading_zero_number(digits: 11) }
+    token           { 'tok_abcdefghijk00000000000000000' }
+
+    association :user_id
+    association :item_id
+  end
+end

--- a/spec/factories/order_form.rb
+++ b/spec/factories/order_form.rb
@@ -4,10 +4,8 @@ FactoryBot.define do
     prefecture_id   { 2 }
     city            { Faker::Address.city }
     address         { Faker::Address.street_address }
+    building_name   { 'ハイツ101号室' }
     phone_number    { Faker::Number.leading_zero_number(digits: 11) }
     token           { 'tok_abcdefghijk00000000000000000' }
-
-    association :user_id
-    association :item_id
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :order do
-    
+    token { 'tok_abcdefghijk00000000000000000' }
   end
 end

--- a/spec/factories/purcheses.rb
+++ b/spec/factories/purcheses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :purchese do
+    
+  end
+end

--- a/spec/factories/shipping_addresses.rb
+++ b/spec/factories/shipping_addresses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :shipping_address do
+    
+  end
+end

--- a/spec/factories/shipping_addresses.rb
+++ b/spec/factories/shipping_addresses.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :shipping_address do
-    
-  end
-end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Item, type: :model do
   before do
     @item = FactoryBot.build(:item)
   end
-
   describe '商品出品' do
     context '商品出品できるとき' do
       it 'nameとdescriptionとprice（300から9999999）と画像が存在、category_id、condition_id、shipping_fee_id、prefecture_idが2以上が選択されているとき' do

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe OrderForm, type: :model do
         @order_form.valid?
         expect(@order_form.errors.full_messages).to include "Post code can't be blank"
       end
-      it 'prefecture_idが空では出品できない' do
-        @order_form.prefecture_id = ''
+      it 'prefecture_idが1では出品できない' do
+        @order_form.prefecture_id = 1
         @order_form.valid?
         expect(@order_form.errors.full_messages).to include "Prefecture can't be blank"
       end
@@ -67,6 +67,11 @@ RSpec.describe OrderForm, type: :model do
         @order_form.user_id = ''
         @order_form.valid?
         expect(@order_form.errors.full_messages).to include("User can't be blank")
+      end
+      it 'item_idが紐づいていなければ購入できない' do
+        @order_form.item_id = ''
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("Item can't be blank")
       end
     end
   end

--- a/spec/models/order_form_spec.rb
+++ b/spec/models/order_form_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe OrderForm, type: :model do
+  before do
+    @user = FactoryBot.create(:user)
+    @item = FactoryBot.create(:item)
+    @order_form = FactoryBot.build(:order_form, user_id: @user.id, item_id: @item.id)
+    sleep(0.5)
+  end
+  describe '商品購入' do
+    context '商品購入できるとき' do
+      it 'post_code,prefecture_id,city,address,phone_numberが入力されているとき' do
+        expect(@order_form).to be_valid
+      end
+      it 'building_nameが空でも購入できること' do
+        @order_form.building_name = ''
+        expect(@order_form).to be_valid
+      end
+    end
+    context '商品購入できないとき' do
+      it 'post_codeが空では出品できない' do
+        @order_form.post_code = ''
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include "Post code can't be blank"
+      end
+      it 'prefecture_idが空では出品できない' do
+        @order_form.prefecture_id = ''
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include "Prefecture can't be blank"
+      end
+      it 'cityが空では出品できない' do
+        @order_form.city = ''
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include "City can't be blank"
+      end
+      it 'addressが空では出品できない' do
+        @order_form.address = ''
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include "Address can't be blank"
+      end
+      it 'phone_numberが空では出品できない' do
+        @order_form.phone_number = ''
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include "Phone number can't be blank"
+      end
+      it 'phone_numberが10桁以下だと購入できない' do
+        @order_form.phone_number = '123456789'
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include('Phone number must be 10 or 11 digits long')
+      end
+      it 'phone_numberが12桁以上だと購入できない' do
+        @order_form.phone_number = '123456789012'
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include('Phone number must be 10 or 11 digits long')
+      end
+      it 'phone_numberが半角数字でないと購入できない' do
+        @order_form.phone_number = '０９０12345678'
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include('Phone number must be 10 or 11 digits long')
+      end
+      it 'tokenが空では購入できない' do
+        @order_form.token = nil
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("Token can't be blank")
+      end
+      it 'user_idが紐づいていなければ購入できない' do
+        @order_form.user_id = ''
+        @order_form.valid?
+        expect(@order_form.errors.full_messages).to include("User can't be blank")
+      end
+    end
+  end
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,5 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Order, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before do
+    @order = FactoryBot.build(:order)
+  end
+
+  context '内容に問題ない場合' do
+    it 'tokenがあれば保存ができること' do
+      expect(@order_form).to be_valid
+    end
+  end
+
+  context '内容に問題がある場合' do
+    it 'tokenが空では登録できないこと' do
+      @order_form.token = nil
+      @order_form.valid?
+      expect(@order_form.errors.full_messages).to include("Token can't be blank")
+    end
+  end
 end

--- a/spec/models/purchese_spec.rb
+++ b/spec/models/purchese_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Purchese, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/shipping_address_spec.rb
+++ b/spec/models/shipping_address_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe ShippingAddress, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/shipping_address_spec.rb
+++ b/spec/models/shipping_address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ShippingAddress, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+
+end


### PR DESCRIPTION
# What
商品購入機能の実装

# Why
商品購入機能実装のため

# Gyazo
必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
①購入後のトップページ
https://gyazo.com/14b0d3cd674bfac46f172ee4719c5edd

②データベース(ordersテーブルの)確認
https://gyazo.com/fb97fbfec4d3192f2305db0b51ee5fdc

③APIの売上確認
https://gyazo.com/d71f0a56ba2b8123d480ef36c58d45cf

入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/c53dcc91988aed12e1ae29a28ccea18b

ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/0d93a852d2eade49ad14113361bca996

ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/22c06f8b8272085d1ffa8ed195927e48

ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/fea6d602dcf28c67273f98503ceea793

売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）
https://gyazo.com/01dfad89f7d40eff1ca3fcfffc22b8cb

売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/c76084ca7762febdbda3ee62af9937c3

ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）
①出品者の画面（商品の編集、削除が無い）
https://gyazo.com/89767a980594afe7380322aa2078f55f

②出品者以外の画面（購入画面に進むが無い）
https://gyazo.com/44709416bc878c6d37f2bbc869207360

ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）
https://gyazo.com/2f6bb61aa5c9bdd199d55c6996d9a024

テスト結果の画像
https://gyazo.com/13fc56703e82742ce06429f11eae1233